### PR TITLE
Potential fix for code scanning alert no. 1: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/src/main/java/service/EncryptionService.java
+++ b/src/main/java/service/EncryptionService.java
@@ -47,15 +47,15 @@ public class EncryptionService {
 
 		SecretKey key = getSecretKey(SECRET_KEY, SALT);
 
-		Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+		Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
 
-		// Generate a random 16-byte IV
-		byte[] iv = new byte[16];
+		// Generate a random 12-byte IV (recommended size for GCM)
+		byte[] iv = new byte[12];
 		SecureRandom sr = new SecureRandom();
 		sr.nextBytes(iv);
-		IvParameterSpec ivSpec = new IvParameterSpec(iv);
+		GCMParameterSpec gcmSpec = new GCMParameterSpec(128, iv); // 128-bit authentication tag
 
-		cipher.init(Cipher.ENCRYPT_MODE, key, ivSpec);
+		cipher.init(Cipher.ENCRYPT_MODE, key, gcmSpec);
 		byte[] encrypted = cipher.doFinal(strToEncrypt.getBytes());
 
 		// Combine IV and encrypted bytes


### PR DESCRIPTION
Potential fix for [https://github.com/tatilimongi/Secure_Password_Manager/security/code-scanning/1](https://github.com/tatilimongi/Secure_Password_Manager/security/code-scanning/1)

To address the issue, replace `AES/CBC/PKCS5Padding` with `AES/GCM/NoPadding`. GCM mode provides both encryption and integrity verification, making it resistant to padding oracle attacks. This change requires updating the encryption logic to handle GCM-specific parameters, such as the authentication tag length. The IV generation remains the same, but the `IvParameterSpec` is replaced with a `GCMParameterSpec`. The decryption logic (not shown here) must also be updated accordingly.

Changes required:
1. Update the `Cipher.getInstance` call to use `AES/GCM/NoPadding`.
2. Replace `IvParameterSpec` with `GCMParameterSpec` and specify an authentication tag length (e.g., 128 bits).
3. Ensure the encrypted output includes the IV and authentication tag for proper decryption.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
