### PR TITLE
Potential fix for code scanning alert no. 2: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/src/main/java/service/EncryptionService.java
+++ b/src/main/java/service/EncryptionService.java
@@ -90,8 +90,9 @@ public class EncryptionService {
 			byte[] encryptedBytes = new byte[encryptedIvTextBytes.length - iv.length];
 			System.arraycopy(encryptedIvTextBytes, iv.length, encryptedBytes, 0, encryptedBytes.length);
 
-			Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
-			cipher.init(Cipher.DECRYPT_MODE, key, ivSpec);
+			Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+			GCMParameterSpec gcmSpec = new GCMParameterSpec(128, iv);
+			cipher.init(Cipher.DECRYPT_MODE, key, gcmSpec);
 			byte[] decrypted = cipher.doFinal(encryptedBytes);
 
 			return new String(decrypted);


### PR DESCRIPTION
Potential fix for [https://github.com/tatilimongi/Secure_Password_Manager/security/code-scanning/2](https://github.com/tatilimongi/Secure_Password_Manager/security/code-scanning/2)

To fix the issue, replace the insecure `AES/CBC/PKCS5Padding` algorithm with `AES/GCM/NoPadding`. GCM mode provides both encryption and authentication, making it resistant to padding oracle attacks. This change requires updating the `Cipher` initialization and handling the GCM-specific requirements, such as using a `GCMParameterSpec` instead of `IvParameterSpec`.

Steps to implement the fix:
1. Replace `AES/CBC/PKCS5Padding` with `AES/GCM/NoPadding` in the `Cipher.getInstance` call.
2. Use `GCMParameterSpec` to specify the IV and authentication tag length (128 bits is standard).
3. Ensure the IV is generated securely and passed correctly during encryption and decryption.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
